### PR TITLE
Changing order of app controller components.

### DIFF
--- a/Controller/AppController.php
+++ b/Controller/AppController.php
@@ -39,8 +39,8 @@ class AppController extends Controller {
 	 * @var array
 	 */
 	public $components = array(
-		'DebugKit.Toolbar',
 		'Session', // => array('className' => 'AppSession'),
+		'DebugKit.Toolbar',
 		'Paginator',
 		'Auth' => array(
 		//	'authError' => 'You must be logged in to access this page.',


### PR DESCRIPTION
If `DebugKit.Toolbar` is before `Session` (when using the `AppSessionComponent`), the `AppSessionComponent` is not used. Justin ran into this [problem as well](https://basecamp.com/1758170/projects/6981136/todos/125269365?moved=true), and it's hard to debug.
