### PR TITLE
Fix for execute files not running after vagrant up, provision, or start

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -120,7 +120,14 @@ Vagrant.configure("2") do |config|
     end
   end
 
-  config.vm.provision :shell, :path => "#{configDir}/shell/execute-files.sh"
+  config.vm.provision :shell do |s|
+    s.path = "#{configDir}/shell/execute-files.sh"
+    s.args = ['exec-once', 'exec-always']
+  end
+  config.vm.provision :shell, run: 'always' do |s|
+    s.path = "#{configDir}/shell/execute-files.sh"
+    s.args = ['startup-once', 'startup-always']
+  end
   config.vm.provision :shell, :path => "#{configDir}/shell/important-notices.sh"
 
   if File.file?("#{configDir}/files/dot/ssh/id_rsa")


### PR DESCRIPTION
This fixes an issue where `exec-once`, `exec-always`, `startup-once`, and `startup-always` were not actually getting run. Please note that https://github.com/loadsys/CakePHP-Skeleton/blob/master/Lib/puphpet/files/exec-once/apt-get-upgrade.sh will now run after this fix.
