### PR TITLE
Always instantiate the /Vendor directory via .gitkeep.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ Thumbs.db
 
 # Composer
 /Vendor
+!/Vendor/.gitkeep
 /bin
 /Plugin/DebugKit
 /Plugin/Migrations


### PR DESCRIPTION
Enforces the presence of the /Vendor dir by including a .gitkeep file (and excluding that .gitkeep file from the master .gitignore.)
