### PR TITLE
Move DB configs into Configure.

### DIFF
--- a/Config/core-staging.php
+++ b/Config/core-staging.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * This is an environment-specific core configuration file.
+ *
+ * It contains staging-specific overrides for the common config settings
+ * in `Config/core.php`. Only items that must truly be different from the
+ * master core config should be added here.
+ *
+ */
+
+$config = array(
+	'debug' => 0,
+
+	/**
+	 * Staging DB configuration. These settings match those used for
+	 * the staging site's MySQL server. Must at least define a `default`
+	 * connection.
+	 */
+	'Database' => array(
+		'default' => array(
+			'datasource' => 'Database/Mysql',
+			'persistent' => false,
+			'host' => '@TODO: Enter staging DB host.',
+			'login' => '@TODO: Enter staging DB login.',
+			'password' => '@TODO: Enter staging DB password.',
+			'database' => '@TODO: Enter staging DB database.',
+		),
+	),
+);

--- a/Config/core-vagrant.php
+++ b/Config/core-vagrant.php
@@ -10,4 +10,32 @@
 
 $config = array(
 	'debug' => 2,
+
+	/**
+	 * Vagrant DB configuration. These settings match those in
+	 * `Lib/puphpet/config.yaml` for the MySQL server that is set up in the
+	 * Vagrant VM. Must at least define a `default` connection.
+	 */
+	'Database' => array(
+		'default' => array(
+			'datasource' => 'Database/Mysql',
+			'persistent' => false,
+			'host' => 'localhost',
+			'login' => 'vagrant',
+			'password' => 'vagrant',
+			'database' => 'vagrant',
+		),
+		'test' => array(
+			'datasource' => 'Database/Mysql',
+			'persistent' => false,
+			'host' => 'localhost',
+			'login' => 'vagrant',
+			'password' => 'vagrant',
+			'database' => 'vagrant_test',
+		),
+		'memory' => array(
+			'datasource' => 'Database/Sqlite',
+			'database' => ':memory:', // Or something independently reviewable, like: 'tmp/treetest.sqlite3',
+		),
+	),
 );

--- a/Config/core.php
+++ b/Config/core.php
@@ -97,6 +97,23 @@ Cache::config('_cake_model_', array(
 //@TODO: Define app-specific vars here.
 
 /**
+ * Default DB configuration. Should be suitable for production use when
+ * no APP_ENV is set. Must at least define a `default` connection.
+ */
+Configure::write('Database', array(
+	'default' => array(
+		'datasource' => 'Database/Mysql',
+		'persistent' => false,
+		'host' => '@TODO: Enter production DB host.',
+		'login' => '@TODO: Enter production DB login.',
+		'password' => '@TODO: Enter production DB password.',
+		'database' => '@TODO: Enter production DB database.',
+		//'prefix' => '',
+		//'encoding' => 'utf8',
+	),
+));
+
+/**
  * Default Site Configuration
  *
  * Any time you'd be tempted to type one of these strings directly into

--- a/Config/database.php
+++ b/Config/database.php
@@ -1,125 +1,44 @@
 <?php
 /**
- * Database connection configuration.
+ * Database connection configuration loader.
+ *
+ * Database connection details will be read from the Configure class.
+ * Production database information should be placed in `app/config/core.php`.
+ * Overrides for staging or vagrant environments should be placed in the
+ * corresponding `app/config/core-*.php` files.
  */
 class DATABASE_CONFIG {
 
 	/**
 	 * Default configuration. Should be suitable for production use when
-	 * no APP_ENV is set.
+	 * no APP_ENV is set. Will be populated by `__construct()` using the
+	 * value from `Configure::read('Database.default')`.
 	 *
 	 * @access	public
-	 * @var	array	$default
+	 * @var	array
 	 */
-	public $default = array(
-		'datasource' => 'Database/Mysql',
-		'persistent' => false,
-		'host' => '@TODO: Enter production DB host.',
-		'login' => '@TODO: Enter production DB login.',
-		'password' => '@TODO: Enter production DB password.',
-		'database' => '@TODO: Enter production DB database.',
-		//'prefix' => '',
-		//'encoding' => 'utf8',
-	);
+	public $default = null;
 
 	/**
-	 * Staging configuration. Used to connect to the staging AWS RDS instance.
-	 *
-	 * @access	public
-	 * @var	array	$vagrant
-	 */
-	public $staging = array(
-		'datasource' => 'Database/Mysql',
-		'persistent' => false,
-		'host' => '@TODO: Enter staging DB host.',
-		'login' => '@TODO: Enter staging DB login.',
-		'password' => '@TODO: Enter staging DB password.',
-		'database' => '@TODO: Enter staging DB database.',
-	);
-
-	/**
-	 * Vagrant configuration. These settings match those in
-	 * `Lib/puphpet/config.yaml` for the MySQL server that is set up in the
-	 * Vagrant VM.
-	 *
-	 * @access	public
-	 * @var	array	$vagrant
-	 */
-	public $vagrant = array(
-		'datasource' => 'Database/Mysql',
-		'persistent' => false,
-		'host' => 'localhost',
-		'login' => 'vagrant',
-		'password' => 'vagrant',
-		'database' => 'vagrant',
-	);
-
-	/**
-	 * Sample AWS Elastic Beanstalk configuration. Because it depends on
-	 * environment variables, it must be set up in `__construct()` below.
-	 * Ref: http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/create_deploy_PHP.rds.html
-	 *
-	 * @access	public
-	 * @var	array	$aws
-	 */
-	public $aws = null;
-
-	/**
-	 * Test configuration. In spite of the constructor below, the TestShell
-	 * should still selectively load the `::$test` config.
-	 *
-	 * @access	public
-	 * @var	array	$test
-	 */
-	public $test = array(
-		'datasource' => 'Database/Mysql',
-		'persistent' => false,
-		'host' => 'localhost',
-		'login' => 'vagrant',
-		'password' => 'vagrant',
-		'database' => 'vagrant_test',
-	);
-
-	/**
-	 * Memory only config. Used by the TreeCheckShell to build a table
-	 * dynamically with the TreeBehavior.
-	 *
-	 * @access	public
-	 * @var	array	$test
-	 */
-	public $memory = array(
-		'datasource' => 'Database/Sqlite',
-		'database' => ':memory:', // Or something independently reviewable, like: 'tmp/treetest.sqlite3',
-	);
-
-	/**
-	 * Set up dynmaic configs and set the appropriate configuration based on
-	 * the APP_ENV environment variable.
-	 *
-	 * If the APP_ENV env var is not set, or set to something that does not
-	 * match one of the available configurations above, 'default' will be used.
+	 * Loads catabase connection information from
+	 * `Configure::read('Database')`, which should be defined in
+	 * `Config/core.php`.
 	 *
 	 * @access	public
 	 * @return	void
 	 */
 	public function __construct() {
-		// Define any configs that depend on dynamic input, such as $_SERVER vars.
-		// We also want to silently ignore if these vars aren't set in any other environment.
-		$rds = array(
-			'datasource' => 'Database/Mysql',
-			'persistent' => false,
-			'host' => @$_SERVER['RDS_HOSTNAME'],
-			'port' => @$_SERVER['RDS_PORT'],
-			'login' => @$_SERVER['RDS_USERNAME'],
-			'password' => @$_SERVER['RDS_PASSWORD'],
-			'database' => @$_SERVER['RDS_DB_NAME'],
-		);
-		$this->aws = $rds;
+		$dbConfigs = Configure::read('Database');
+		if (!is_array($dbConfigs)) {
+			throw new Exception('No `Database` connections defined in core.php.');
+		}
 
-		// Determine which config is the "default" for the given environment.
-		$available = array_keys(get_class_vars('DATABASE_CONFIG'));
-		$env = getenv('APP_ENV');
-		$env = (in_array($env, $available) ? $env : 'default');
-		$this->default = $this->{$env};
+		foreach ($dbConfigs as $key => $config) {
+			$this->{$key} = $config;
+		}
+
+		if (!property_exists($this, 'default') || !is_array($this->default)) {
+			throw new Exception('No `Database.default` connection defined in core.php.');
+		}
 	}
 }


### PR DESCRIPTION
Fixes #36.

This change will break the db-credentials and db-backup scripts in the CakePHP Shell Scripts repo, since they depend on include()ing the database.php file directly. They need to be updated to use the ConfigReadShell if it's available. See loadsys/CakePHP-Shell-Scripts#32.
