### PR TITLE
F/gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,24 @@
+# Composer Dependencies
 /vendor/*
+/bin
 
-# Puphpet / Vagrant ignored files
+# Puphpet and Vagrant ignored files
 /.vagrant/
 /puphpet/files/dot/ssh/*id_rsa*
+
+# Backups Folder
+/backups
+
+# OS X
+.DS_Store
+.AppleDouble
+.LSOverride
+Icon?
+._*
+.Spotlight-V100
+.Trashes
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+# Project-Specific Ignores
+
 # Composer Dependencies
 /vendor/*
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # Composer Dependencies
 /vendor/*
-/bin
 
 # Puphpet and Vagrant ignored files
 /.vagrant/

--- a/bin/.gitignore
+++ b/bin/.gitignore
@@ -1,0 +1,9 @@
+# Remember Cake Shells
+!.gitignore
+!.gitkeep
+/!cake
+/!cake.bat
+/!cake.php
+
+# Ignore everything else in the /bin folder
+/*


### PR DESCRIPTION
Updated .gitignore file.

Ignores OS X generic stuff, ignores `/backups` folder, ignores `/bin` folder except for the CakePHP stuff.

Closes #60 