### PR TITLE
Flip display name and email address in email configuration

### DIFF
--- a/Config/core.php
+++ b/Config/core.php
@@ -146,7 +146,7 @@ Configure::write('Defaults', array(
 $email = function($localAddress, $displayName = false) {
 	$displayName = ($displayName ?: Configure::read('Defaults.short_name'));
 	$address = sprintf('%s@%s', $localAddress, Configure::read('Defaults.domain'));
-	return array($displayName => $address);
+	return array($address => $displayName);
 };
 
 /**

--- a/Config/core.php
+++ b/Config/core.php
@@ -160,7 +160,9 @@ $email = function($localAddress, $displayName = false) {
  * To use Address slugs, either pass the result straight to AppEmail, or
  * unpack a config key in your code like so:
  *
- * `list($name, $email) = Configure::read('Email.Address.slugname');`
+ * 		$address = Configure::read('Email.Address.slugname');
+ * 		$email = key($address);
+ * 		$display = current($address);
  */
 Configure::write('Email', array(
 	'Address' => array(

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -90,8 +90,8 @@ Vagrant.configure('2') do |config|
 
   data['vm']['synced_folder'].each do |i, folder|
     if folder['source'] != '' && folder['target'] != ''
-      sync_owner = !folder['owner'].nil? ? folder['owner'] : 'www-data'
-      sync_group = !folder['group'].nil? ? folder['group'] : 'www-data'
+      sync_owner = !folder['sync_owner'].nil? ? folder['sync_owner'] : 'www-data'
+      sync_group = !folder['sync_group'].nil? ? folder['sync_group'] : 'www-data'
 
       if folder['sync_type'] == 'nfs'
         config.vm.synced_folder "#{folder['source']}", "#{folder['target']}", id: "#{i}", type: 'nfs', :linux__nfs_options => ["rw","no_root_squash","no_subtree_check"] # Ref: https://github.com/puphpet/puphpet/wiki/Shared-Folder:-Permission-Denied -bp

--- a/puphpet/config.yaml
+++ b/puphpet/config.yaml
@@ -39,8 +39,8 @@ vagrantfile-local:
                     - '--parser future'
         synced_folder:
             project_root:
-                owner: www-data
-                group: www-data
+                sync_owner: www-data
+                sync_group: www-data
                 source: ./
                 target: /var/www
                 sync_type: nfs  # Or `default` but `nfs` performs better and is (likely) required when using vmware.


### PR DESCRIPTION
This fixes an incorrectly assigned name/address pair in the $email. Not ready to merge this yet until I confirm on another project (we had other issues holding us up). Also waiting on a demo from Brian to possibly change an example below this change.