### PR TITLE
Corrects Dir for CustomKey Location

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -251,7 +251,7 @@ Vagrant.configure('2') do |config|
   end
   config.vm.provision :shell, :path => 'puphpet/shell/important-notices.sh'
 
-  customKey  = "#{dir}/files/dot/ssh/id_rsa"
+  customKey  = "#{dir}/puphpet/files/dot/ssh/id_rsa"
   vagrantKey = "#{dir}/.vagrant/machines/default/#{ENV['VAGRANT_DEFAULT_PROVIDER']}/private_key"
 
   if File.file?(customKey)


### PR DESCRIPTION
The dir from the top is the root directory of the project, which does not include a `puphpet` path where all the `puphpet` files and such are contained.

Corrects this issue.

Related PR for Cake2 Branch: https://github.com/loadsys/CakePHP-Skeleton/pull/104