### PR TITLE
Adjusts phpunit.xml paths for Cake 3. Enables clover.xml.

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -35,18 +35,16 @@
 		<!-- HTML reports intended to be exported to loadsysdev for viewing. -->
 		<log
 			type="coverage-html"
-			target="../tmp/coverage/html/"
+			target="./tmp/coverage/html/"
 			charset="UTF-8"
 			highlight="true"
 			lowUpperBound="60"
 			highLowerBound="90"
 		/>
-		<!-- Not currently used, but include the config anyway so it's here already. -->
-		<!-- 
+		<!-- Used to provide coverage percentage to `coverage-ensure` from the CakePHP-Shell-Scripts repo. -->
 		<log
 			type="coverage-clover"
-			target="../tmp/coverage/clover.xml"
+			target="./tmp/coverage/clover.xml"
 		/>
-		-->
 	</logging>
 </phpunit>


### PR DESCRIPTION
This work may still be slightly incomplete on the Shell Scripts end of things, but no harm getting it in here now.