### PR TITLE
Cakephp/app updates from 3.0.2 to 3.0.3

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -44,6 +44,7 @@ use Cake\Core\App;
 use Cake\Core\Configure;
 use Cake\Core\Configure\Engine\PhpConfig;
 use Cake\Core\Plugin;
+use Cake\Database\Type;
 use Cake\Datasource\ConnectionManager;
 use Cake\Error\ErrorHandler;
 use Cake\Log\Log;
@@ -202,3 +203,9 @@ if (Configure::read('debug')) {
 DispatcherFactory::add('Asset');
 DispatcherFactory::add('Routing');
 DispatcherFactory::add('ControllerFactory');
+
+/**
+ * Enable default locale format parsing.
+ * This is needed for matching the auto-localized string output of Time() class when parsing dates.
+ */
+Type::build('datetime')->useLocaleParser();


### PR DESCRIPTION
Part of the 3.0.3 update had already been merged. This PR contains the single remaining commit .

- Enable parsing locale dates by default to match auto localization of Time() when used as string in form inputs.