### PR TITLE
Symlink the shutdown script properly.

### DIFF
--- a/provision/main.sh
+++ b/provision/main.sh
@@ -155,9 +155,9 @@ EOSHL
 
 sudo chmod a+x "${SHUTDOWN_DB_BACKUP_SCRIPT}"
 
-sudo ln -s /etc/init.d/"${SHUTDOWN_DB_BACKUP_SCRIPT}" /etc/rc0.d/`basename "${SHUTDOWN_DB_BACKUP_SCRIPT}"`
+sudo ln -s "${SHUTDOWN_DB_BACKUP_SCRIPT}" /etc/rc0.d/`basename "${SHUTDOWN_DB_BACKUP_SCRIPT}"`
 
-sudo ln -s /etc/init.d/"${SHUTDOWN_DB_BACKUP_SCRIPT}" /etc/rc6.d/`basename "${SHUTDOWN_DB_BACKUP_SCRIPT}"`
+sudo ln -s "${SHUTDOWN_DB_BACKUP_SCRIPT}" /etc/rc6.d/`basename "${SHUTDOWN_DB_BACKUP_SCRIPT}"`
 
 
 # Call the environment-specific provisioning script, if it exists.


### PR DESCRIPTION
Corrects a typo in the vagrant shutdown script that is intended to make a backup of the VM's MySQL database every time the vagrant VM is halted. This provides pretty good data protection from accidentally `vagrant destroy`ing the box, and now it should actually work as intended.