### PR TITLE
Change Default Session Implementation To Use Cache

### DIFF
--- a/.travis.yml.template
+++ b/.travis.yml.template
@@ -49,7 +49,7 @@ before_script:
 script:
   # Note you may want to use the -n option for the CodeSniffer to ignore warnings
   - bin/phpcs -ps --extensions=php --standard=Loadsys ./src ./tests ./config ./webroot ./plugins
-  - bin/phpunit
+  - bin/phpunit -v
 
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The 3.x version of the skeleton leverages composer's `create-project` command. A
 
 ```bash
 composer self-update # Generally a good idea to run first.
-composer create-project --prefer-dist --ignore-platform-reqs loadsys/skeleton local/path/for/new/project ~3.1
+composer create-project --prefer-dist --ignore-platform-reqs loadsys/skeleton local/path/for/new/project ~3.2
 # (Answer wizard questions.)
 cd local/path/for/new/project
 ./bootstrap.sh vagrant

--- a/composer.json.template
+++ b/composer.json.template
@@ -45,6 +45,6 @@
       "Cake\\Composer\\Installer\\PluginInstaller::postAutoloadDump"
     ]
   },
-  "minimum-stability" : "dev",
+  "minimum-stability": "dev",
   "prefer-stable": true
 }

--- a/config/app-staging.php
+++ b/config/app-staging.php
@@ -40,6 +40,13 @@ return [
 			'username' => null,
 			'password' => null,
 		],
+		'sessions' =>[
+			'compress' => false,
+			'duration' => 120,
+			'servers' => 'localhost',
+			'username' => null,
+			'password' => null,
+		],
 	],
 
 	/**

--- a/config/app-travis.php
+++ b/config/app-travis.php
@@ -40,6 +40,13 @@ return [
 			'username' => null,
 			'password' => null,
 		],
+		'sessions' =>[
+			'compress' => false,
+			'duration' => 120,
+			'servers' => 'localhost',
+			'username' => null,
+			'password' => null,
+		],
 	],
 
 	/**

--- a/config/app-vagrant.php
+++ b/config/app-vagrant.php
@@ -41,6 +41,13 @@ return [
 			'username' => null,
 			'password' => null,
 		],
+		'sessions' =>[
+			'compress' => false,
+			'duration' => 120,
+			'servers' => 'localhost',
+			'username' => null,
+			'password' => null,
+		],
 	],
 
 	/**

--- a/config/app.default.php
+++ b/config/app.default.php
@@ -108,6 +108,15 @@ return [
 		]),
 
 		/**
+		 * Configure the cache for session caching. This cache configuration
+		 * is used to store the session information. To update where Sessions
+		 * are stored modify this array.
+		 */
+		'sessions' => ConfigClosures::cacheMerge([
+			'prefix' => 'sessions_',
+		]),
+
+		/**
 		 * An example of a "simple" File config, for reference.
 		 *
 		 * Caching should be via Memcached by default though.
@@ -335,7 +344,12 @@ return [
 	 * To use database sessions, load the SQL file located at config/Schema/sessions.sql
 	 */
 	'Session' => [
+		// The Default Session configuration uses the Caching Engine
+		// (Memchached) with the `sessions` Cache config.
 		'defaults' => 'cache',
+		'handler' => [
+			'config' => 'sessions'
+		]
 	],
 
 	/**

--- a/config/app.default.php
+++ b/config/app.default.php
@@ -335,7 +335,7 @@ return [
 	 * To use database sessions, load the SQL file located at config/Schema/sessions.sql
 	 */
 	'Session' => [
-		'defaults' => 'php',
+		'defaults' => 'cache',
 	],
 
 	/**

--- a/config/app.default.php
+++ b/config/app.default.php
@@ -1,7 +1,6 @@
 <?php
 
 use App\Lib\ConfigClosures;
-use Cake\Utility\Hash;
 
 return [
 	/**
@@ -28,8 +27,8 @@ return [
 	 * - baseUrl - To configure CakePHP to *not* use mod_rewrite and to
 	 *   use CakePHP pretty URLs, remove these .htaccess
 	 *   files:
-	 *	  /.htaccess
-	 *	  /webroot/.htaccess
+	 *      /.htaccess
+	 *      /webroot/.htaccess
 	 *   And uncomment the baseUrl key below.
 	 * - fullBaseUrl - A base URL to use for absolute links.
 	 * - imageBaseUrl - Web path to the public images directory under webroot.
@@ -95,7 +94,7 @@ return [
 		 * configuration.
 		 */
 		'_cake_core_' => ConfigClosures::cacheMerge([
-			'prefix' => 'cake_core_',
+			'prefix' => '_cake_core_',
 		]),
 
 		/**
@@ -104,7 +103,7 @@ return [
 		 * in connections.
 		 */
 		'_cake_model_' => ConfigClosures::cacheMerge([
-			'prefix' => 'cake_model_',
+			'prefix' => '_cake_model_',
 		]),
 
 		/**
@@ -321,13 +320,13 @@ return [
 	 * - `cookiePath` - The url path for which session cookie is set. Maps to the
 	 *   `session.cookie_path` php.ini config. Defaults to base path of app.
 	 * - `timeout` - The time in minutes the session should be valid for.
-	 *	Pass 0 to disable checking timeout.
+	 *    Pass 0 to disable checking timeout.
 	 * - `defaults` - The default configuration set to use as a basis for your session.
-	 *	There are four built-in options: php, cake, cache, database.
+	 *    There are four built-in options: php, cake, cache, database.
 	 * - `handler` - Can be used to enable a custom session handler. Expects an
-	 *	array with at least the `engine` key, being the name of the Session engine
-	 *	class to use for managing the session. CakePHP bundles the `CacheSession`
-	 *	and `DatabaseSession` engines.
+	 *    array with at least the `engine` key, being the name of the Session engine
+	 *    class to use for managing the session. CakePHP bundles the `CacheSession`
+	 *    and `DatabaseSession` engines.
 	 * - `ini` - An associative array of additional ini values to set.
 	 *
 	 * The built-in `defaults` options are:
@@ -375,5 +374,17 @@ return [
 				'Snippet' => '',
 			],
 		],
+	],
+
+	/**
+	 * Define a number of static lookup [slug => Display Value] lists.
+	 *
+	 * These should be kept small since they will be loaded into memory
+	 * with every request.
+	 *
+	 * Top-level keys should match the Entity/Table, second-level keys
+	 * should match `*_slug` field names.
+	 */
+	'Lists' => [
 	],
 ];

--- a/phpdoc.dist.xml.template
+++ b/phpdoc.dist.xml.template
@@ -17,7 +17,7 @@
 	</files>
 
 	<parser>
-		<default-package-name>{{PROJECT_DEFAULT_NAMESPACE:App}}</default-package-name>
+		<default-package-name>App</default-package-name>
 
 		<encoding>utf-8</encoding>
 		<target>./tmp/docs-build</target>

--- a/provision/main.sh
+++ b/provision/main.sh
@@ -120,6 +120,10 @@ sudo cp -r ${PROVISION_DIR}/dot-files/.[a-zA-Z0-9]* "/home/${TARGET_USER}/" && \
  sudo cp -r ${PROVISION_DIR}/dot-files/.[a-zA-Z0-9]* /root/
 
 
+# Automatically switch to the webroot when logging in.
+echo "cd /var/www" >> "/home/${TARGET_USER}/.profile"
+
+
 # Set up Apache config.
 echo "## Setting up Apache virtual host."
 

--- a/src/Lib/ConfigClosures.php
+++ b/src/Lib/ConfigClosures.php
@@ -32,7 +32,7 @@ class ConfigClosures {
 			'className' => 'Memcached',
 			'compress' => true,
 			'duration' => '+1 years',
-			'prefix' => 'eu_',
+			'prefix' => '@TODO_',
 			'servers' => '@TODO: Default (prod) Memcached server address',
 			'username' => '@TODO: Default (prod) Memcached server username',
 			'password' => '@TODO: Default (prod) Memcached server password',

--- a/src/Shell/ConsoleShell.php
+++ b/src/Shell/ConsoleShell.php
@@ -7,6 +7,8 @@
  * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
+ * @codeCoverageIgnore
+ *
  * @copyright Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link      http://cakephp.org CakePHP(tm) Project
  * @since     3.0.0

--- a/tests/TestCase/Lib/ConfigClosuresTest.php
+++ b/tests/TestCase/Lib/ConfigClosuresTest.php
@@ -1,11 +1,14 @@
 <?php
+/**
+ * Tests for the ConfigClosures Lib Class.
+ */
 namespace App\Test\TestCase\Lib;
 
 use App\Lib\ConfigClosures;
 use Cake\TestSuite\TestCase;
 
 /**
- * ConfigClosures tests
+ * \App\Test\TestCase\Lib\ConfigClosuresTest
  */
 class ConfigClosuresTest extends TestCase {
 	/**


### PR DESCRIPTION
- [x] Update Sessions Configuration To Use Cache
- [x] Add Session Configuration to the Cache Block, should default to mirror default Cache Configuration
- [x] Edit Session Configuration to Use Session Cache Block
- [x] Add Comments Explaining both where sessions live, how they are cached and how to separate them from normal caching if desired at a later date/time