### PR TITLE
Update production.sh to proceed with tested changes

### DIFF
--- a/provision/production.sh
+++ b/provision/production.sh
@@ -21,8 +21,8 @@
 FQDN="@TODO:hostname.domain.com"
 NOTIFY_EMAIL="@TODO:serveradmin@domain.com"
 SMTP_RELAY_HOST_AND_PORT="@TODO:ses.hostname.here:587"
-SMTP_RELAY_PASSWORD="@TODO:ses-password-here"
-
+SMTP_RELAY_USERNAME="@TODO:ses.username-here"
+SMTP_RELAY_PASSWORD="@TODO:ses.password-here"
 
 echo "## Starting: `basename "$0"`."
 
@@ -60,13 +60,13 @@ echo "## Starting: `basename "$0"`."
 
 DEBIAN_FRONTEND=noninteractive sudo apt-get install -y postfix  # Choose "no configuration" from the menu if it appears.
 
-tee /etc/mailname <<EOF > /dev/null
+sudo tee /etc/mailname <<EOF > /dev/null
 ${FQDN}
 
 EOF
 
 
-tee /etc/postfix/main.cf <<EOF > /dev/null
+sudo tee /etc/postfix/main.cf <<EOF > /dev/null
 relayhost = ${SMTP_RELAY_HOST_AND_PORT}
 smtp_sasl_auth_enable = yes
 smtp_sasl_security_options = noanonymous
@@ -79,15 +79,16 @@ smtp_tls_CAfile = /etc/ssl/certs/ca-certificates.crt
 EOF
 
 
-tee /etc/postfix/sasl_passwd <<'EOF' > /dev/null
-${SMTP_RELAY_HOST_AND_PORT} ${SMTP_RELAY_PASSWORD}
+sudo tee /etc/postfix/sasl_passwd <<EOF > /dev/null
+${SMTP_RELAY_HOST_AND_PORT} ${SMTP_RELAY_USERNAME}:${SMTP_RELAY_PASSWORD}
 
 EOF
 
+sudo postmap /etc/postfix/sasl_passwd
 
 sudo cp /etc/aliases /etc/alises.bak
 
-tee /etc/aliases <<EOF > /dev/null
+sudo tee /etc/aliases <<EOF > /dev/null
 # See man 5 aliases for format
 #
 # Forward local accounts to root's mailbox.


### PR DESCRIPTION
This removes `exit 0` and includes changes we've used on a production app. The script is safe to run multiple times without ill effect. A few things of note we learned along the way:

* Most email relay configurations require both a username and password.
* Postfix sasl won't work without running `postmap /etc/postfix/sasl_passwd` to generate the `sasl_passwd.db` file.
* Comments aren't interpreted correctly in direct calls to a command, as seen [here](https://github.com/loadsys/CakePHP-Skeleton/compare/f/production-updates?expand=1#diff-11bc9a86232e11d500fcd07370521ce1L60) (which executed the next uncommented line as a command).

cc: @ricog 