### PR TITLE
F/minor tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,11 +5,11 @@
 /config/app-local.php
 /backups/
 /.vagrant/
-/puphpet/files/dot/ssh/*id_rsa*
 /phpunit.xml
 
 # Composer Dependencies
 /vendor/*
+/node_modules
 
 # OS X
 .DS_Store

--- a/.travis.yml.template
+++ b/.travis.yml.template
@@ -44,14 +44,12 @@ install:
 before_script:
   - phpenv rehash
   - mysql -e 'DROP DATABASE IF EXISTS `travis_app`; CREATE DATABASE `travis_app`;'
-  - bin/phpcs --config-set installed_paths vendor/loadsys/loadsys_codesniffer,vendor/cakephp/cakephp-codesniffer
 
 script:
   # The -n option can be used to suppress warnings
   - bin/codesniffer-run
   - bin/phpunit -v
-  # Disabled Coverage Check, the param defines the required percentage of code covered
-  # - bin/coverage-ensure 90
+  - bin/coverage-ensure 90
 
 notifications:
   email: false

--- a/README.md.template
+++ b/README.md.template
@@ -138,11 +138,8 @@ The bootstrap file takes care of installing dependencies. After this process, th
 	* Assign a user permissions to that database.
 	* (Locally) Update the `config/app.php` with the new credentials and commit/push them to GitHub.
 1. Create or provision a new web instance server, preferably matching the Vagrant `box` in use (or vice-versa).
-	1. Install git v1.8+
-	1. `cd` into the intended webroot (typically `/var/www`).
-	1. Clone the project and provision the server:
-			git clone {{PROJECT_REPO_HTTPS_URL:@TODO}} ./
-			./bootstrap.sh YOUR_APP_ENV_VALUE
+	1. ssh into the box.
+	1. Run `https://raw.githubusercontent.com/loadsys/CakePHP-Shell-Scripts/master/baremetal-bootstrap | bash -s -- {{PROJECT_REPO_HTTPS_URL:@TODO}} NEW_APP_ENV_HERE BRANCH_NAME_HERE`
 
 
 ### Writeable Directories

--- a/provision/baremetal.sh
+++ b/provision/baremetal.sh
@@ -7,11 +7,10 @@
 
 
 # Set up working vars.
-#   PROVISION_DIR must be inherited from main.sh
-#   APP_ENV must be inherited from main.sh
-
-# Expects:
-#FQDN
+#   PROVISION_DIR must be inherited from caller.
+#   APP_ENV must be inherited from caller.
+#   TARGET_USER must be inherited from caller.
+#   FQDN must be inherited from caller.
 
 
 echo "## Starting: `basename "$0"`."

--- a/provision/production.sh
+++ b/provision/production.sh
@@ -15,10 +15,11 @@
 
 
 # Set up working vars.
-#   PROVISION_DIR must be inherited from main.sh
-#   APP_ENV must be inherited from main.sh
+#   PROVISION_DIR must be inherited from caller.
+#   APP_ENV must be inherited from caller.
+#   TARGET_USER must be inherited from caller.
 
-FQDN="@TODO:hostname.domain.com"
+export FQDN="@TODO:hostname.domain.com"
 NOTIFY_EMAIL="@TODO:serveradmin@domain.com"
 SMTP_RELAY_HOST_AND_PORT="@TODO:ses.hostname.here:587"
 SMTP_RELAY_USERNAME="@TODO:ses.username-here"

--- a/src/Shell/ConsoleShell.php
+++ b/src/Shell/ConsoleShell.php
@@ -7,12 +7,12 @@
  * For full copyright and license information, please see the LICENSE.txt
  * Redistributions of files must retain the above copyright notice.
  *
- * @codeCoverageIgnore
- *
  * @copyright Copyright (c) Cake Software Foundation, Inc. (http://cakefoundation.org)
  * @link      http://cakephp.org CakePHP(tm) Project
  * @since     3.0.0
  * @license   http://www.opensource.org/licenses/mit-license.php MIT License
+ *
+ * @codeCoverageIgnore
  */
 namespace App\Shell;
 
@@ -23,6 +23,8 @@ use Psy\Shell as PsyShell;
 
 /**
  * Simple console wrapper around Psy\Shell.
+ *
+ * @codeCoverageIgnore
  */
 class ConsoleShell extends Shell {
 

--- a/tests/TestCase/Controller/PagesControllerTest.php
+++ b/tests/TestCase/Controller/PagesControllerTest.php
@@ -9,7 +9,7 @@ use Cake\ORM\TableRegistry;
 use Cake\TestSuite\IntegrationTestCase;
 
 /**
- * \App\Test\TestCases\Controller\PagesControllerTest
+ * \App\Test\TestCase\Controller\PagesControllerTest
  */
 class PagesControllerTest extends IntegrationTestCase {
 	/**

--- a/tests/TestCase/Migrations/MigrationsTest.php
+++ b/tests/TestCase/Migrations/MigrationsTest.php
@@ -1,0 +1,300 @@
+<?php
+/**
+ * Migrations tests.
+ *
+ * Checks each migration file for specific characteristics. This is really
+ * more of a code-sniff style check, but it's in place to help ensure the
+ * quality of the DB schemas we design and deploy.
+ */
+
+namespace App\Test\TestCase\Migrations;
+
+use Cake\TestSuite\TestCase;
+use Cake\Utility\Inflector;
+use Phinx\Db\Table;
+use Phinx\Migration\AbstractMigration;
+use \FilesystemIterator;
+use \GlobIterator;
+
+/**
+ * Migrations folder iterator.
+ *
+ * Returns each file in the Migrations folder as an array of relevant
+ * info. Used to seed the dataProvider for testMigrationFile().
+ */
+class MigrationFolderIterator extends GlobIterator {
+	public function current() {
+		$fileInfo = parent::current();
+		$filename = $fileInfo->getBasename();
+		list($version, $underscoredName) = explode('_', $filename, 2);
+		$classname = Inflector::camelize(basename($underscoredName, '.php'));
+		//@DEBUG: return compact('filename', 'classname', 'version');
+		return [$fileInfo->getRealPath(), $classname, $version];
+	}
+}
+
+/**
+ * Migrations test cases
+ */
+class MigrationsTest extends TestCase {
+	/**
+	 * The Mocked Table instance being operated on.
+	 *
+	 * @var mixed
+	 */
+	public $table = null;
+
+	/**
+	 * The table name being operated on.
+	 *
+	 * @var string
+	 */
+	public $tableName = null;
+
+	/**
+	 * Array of properties for each table being processed.
+	 *
+	 * @var array
+	 */
+	public $tableProperties = [];
+
+	/**
+	 * setUp method
+	 *
+	 * @return void
+	 */
+	public function setUp() {
+		parent::setUp();
+	}
+
+	/**
+	 * tearDown method
+	 *
+	 * @return void
+	 */
+	public function tearDown() {
+		unset($this->migration, $this->table, $this->tableName, $this->tableProperties);
+		parent::tearDown();
+	}
+
+	/**
+	 * Test an individual migration file.
+	 *
+	 * Migrations must conform to a set of constraints:
+	 *
+	 *    - All tables and columns must include a non-empty [comment] key.
+	 *
+	 * @param string $filename The full filesystem path to the Migration file to load.
+	 * @param string $classname The inferred (inflected) name of the Migration class.
+	 * @param string $version The inferred version number of the Migration, taken from the timestamp in the filename.
+	 * @return void
+	 * @dataProvider provideMigrationFiles
+	 */
+	public function testMigrationFile($filename, $classname, $version) {
+		include $filename;
+		$this->mockMigration($classname, $version);
+
+		// Trigger the up() and/or change() methods. (The mocks provide the assertions.)
+		$this->migration->up();
+		if (is_callable([$this->migration, "change"])) {
+			$this->migration->change();
+		}
+	}
+
+	/**
+	 * Scan the Migrations folder and return arrays of file and class names to test.
+	 *
+	 * @return void
+	 */
+	public function provideMigrationFiles() {
+		$globPath = dirname(dirname(dirname(dirname(__FILE__)))) . '/config/Migrations/*.php';
+		$it = new MigrationFolderIterator($globPath, FilesystemIterator::KEY_AS_FILENAME);
+		return $it;
+	}
+
+	/**
+	 * Mock the migration class to spy on schema change methods.
+	 *
+	 * @return mixed
+	 */
+	protected function mockMigration($class, $version) {
+		// The mocked Table object must enforce some constraints its columns.
+		$this->table = $this->getMock('Phinx\Db\Table', [], [], '', false);
+		$this->table->expects($this->any())
+			->method('create')
+			->will($this->returnCallback([$this, 'assertTableOptions']));
+		$this->table->expects($this->any())
+			->method($this->anything())
+			->will($this->returnCallback([$this, 'assertOptions']));
+
+		// The Migration just needs to return an instance of the mocked Table.
+		$this->migration = $this->getMock($class, ['table'], [$version]);
+		$this->migration->expects($this->any())
+			->method('table')
+			->will($this->returnCallback([$this, 'collectTableProperties']));
+	}
+
+	/**
+	 * Collect the Table name and other properties.
+	 *
+	 * @return mixed Returns the table instance for the fluid interface.
+	 */
+	public function collectTableProperties() {
+		$args = func_get_args();
+		$this->tableName = $args[0];
+		$this->tableProperties = (count($args) > 1 ? $args[1] : []);
+		return $this->table; // Preserve the fluent interface of the mocked Table object.
+	}
+
+	/**
+	 * Callback method to assert that a table Migration call when called from
+	 * create has a subset of options. It is used to provide the correct
+	 * parameters to assertOptions.
+	 *
+	 * @return void
+	 */
+	public function assertTableOptions() {
+		$this->assertOptions($this->tableName, $this->tableProperties);
+	}
+
+	/**
+	 * returnCallback() function used by mocked methods.
+	 *
+	 * Used as the return value callback function in the mocked
+	 * AbstractMigration::table() and Table::addColumn() methods to verify
+	 * the arguments passed to those methods.
+	 *
+	 * @return mixed
+	 */
+	public function assertOptions() {
+		$args = func_get_args();
+
+		// @codingStandardsIgnoreStart
+		$calledFunctionName = @debug_backtrace(null)[5]['function'];
+		// @codingStandardsIgnoreEnd
+
+		// Handle the pass-thru from ::assertTableOptions() specially.
+		if ($calledFunctionName == 'invoke') {
+			$calledFunctionName = 'table';
+		}
+
+		switch ($calledFunctionName) {
+			case 'table':
+				$options = $this->tableProperties;
+				$this->assertKeyNotEmpty('comment', $options, $this->tableName, $calledFunctionName, null);
+				break;
+
+			case 'addColumn':
+				list($fieldName, $fieldType, $options) = $args;
+				$this->assertKeyNotEmpty('comment', $options, $this->tableName, $calledFunctionName, $fieldName);
+				$this->assertHasKey('default', $options, $this->tableName, $calledFunctionName, $fieldName);
+				$this->assertHasKey('null', $options, $this->tableName, $calledFunctionName, $fieldName);
+				$this->assertHasKey('limit', $options, $this->tableName, $calledFunctionName, $fieldName);
+
+				if (is_callable([$this, "assert{$fieldType}"])) {
+					call_user_func(
+						[$this, "assert{$fieldType}"],
+						$options,
+						$this->tableName,
+						$calledFunctionName,
+						$fieldName
+					);
+				}
+				break;
+
+			default:
+				break;
+		}
+
+		return $this->table; // Preserve the fluent interface of the mocked Table object.
+	}
+
+	/**
+	 * Custom assertion to ensure the given array has a [key] element.
+	 *
+	 * @param string $key The key to assert exists.
+	 * @param array $array An array, typically options for the migration method, obtained from the mocked call to table() or addColumn(), etc. in the Migration file.
+	 * @param string $table The name of the "current" table the Migration file is operating on. This is stateful given the fluent nature of phinx migrations. Set by ::assertOptions(). Used to provide more accurate assertion failure messages.
+	 * @param string $method The name of the current method being called in the migration file. Used to provide more accurate assertion failure messages.
+	 * @param string $field The name of the field being modified by the migration. Context-sensitive. Used to provide more accurate assertion failure messages.
+	 * @return void
+	 */
+	public function assertHasKey($key, $array, $table, $method, $field) {
+		$signature = "table({$table}" . ($method == 'table' ? '' : ")->{$method}({$field}") . ', [options])';
+		$this->assertArrayHasKey(
+			$key,
+			$array,
+			"{$signature}: must contain a [$key] element."
+		);
+	}
+
+	/**
+	 * Custom assertion to ensure the given array has a non-empty [key] element.
+	 *
+	 * @param string $key The key to assert exists and is not empty.
+	 * @param array $array An array, typically options for the migration method, obtained from the mocked call to table() or addColumn(), etc. in the Migration file.
+	 * @param string $table The name of the "current" table the Migration file is operating on. This is stateful given the fluent nature of phinx migrations. Set by ::assertOptions(). Used to provide more accurate assertion failure messages.
+	 * @param string $method The name of the current method being called in the migration file. Used to provide more accurate assertion failure messages.
+	 * @param string $field The name of the field being modified by the migration. Context-sensitive. Used to provide more accurate assertion failure messages.
+	 * @return void
+	 */
+	public function assertKeyNotEmpty($key, $array, $table, $method, $field) {
+		$signature = "table({$table}" . ($method == 'table' ? '' : ")->{$method}({$field}") . ', [options])';
+		$this->assertHasKey($key, $array, $table, $method, $field);
+		$this->assertNotEmpty(
+			$array[$key],
+			"{$signature}: [$key] must be non-empty."
+		);
+	}
+
+	/**
+	 * Custom assertion to ensure that DECIMAL field types defined both a [precision] and a [scale].
+	 *
+	 * @param array $options An array of options obtained from the mocked call to table() or addColumn(), etc. in the Migration file.
+	 * @param string $table The name of the "current" table the Migration file is operating on. This is stateful given the fluent nature of phinx migrations. Set by ::assertOptions(). Used to provide more accurate assertion failure messages.
+	 * @param string $method The name of the current method being called in the migration file. Used to provide more accurate assertion failure messages.
+	 * @param string $field The name of the field being modified by the migration. Context-sensitive. Used to provide more accurate assertion failure messages.
+	 * @return void
+	 */
+	public function assertDecimal($options, $table, $method, $field) {
+		$signature = "table({$table}" . ($method == 'table' ? '' : ")->{$method}({$field}") . ', [options])';
+		$this->assertArrayHasKey(
+			'precision',
+			$options,
+			"{$signature}: must contain a [precision] element."
+		);
+		$this->assertArrayHasKey(
+			'scale',
+			$options,
+			"{$signature}: must contain a [scale] element."
+		);
+		if (array_key_exists('limit', $options)) {
+			$this->assertEmpty(
+				$options['limit'],
+				"{$signature}: [limit] element on DECIMAL fields must be null."
+			);
+		}
+	}
+
+	/**
+	 * Custom assertion to ensure that TINYINT(1) (boolean) field types define an [unsigned => true] option.
+	 *
+	 * @param array $options An array of options obtained from the mocked call to table() or addColumn(), etc. in the Migration file.
+	 * @param string $table The name of the "current" table the Migration file is operating on. This is stateful given the fluent nature of phinx migrations. Set by ::assertOptions(). Used to provide more accurate assertion failure messages.
+	 * @param string $method The name of the current method being called in the migration file. Used to provide more accurate assertion failure messages.
+	 * @param string $field The name of the field being modified by the migration. Context-sensitive. Used to provide more accurate assertion failure messages.
+	 * @return void
+	 */
+	public function assertBoolean($options, $table, $method, $field) {
+		$signature = "table({$table}" . ($method == 'table' ? '' : ")->{$method}({$field}") . ', [options])';
+		$this->assertArrayHasKey(
+			'signed',
+			$options,
+			"{$signature}: must contain a [signed] element."
+		);
+		$this->assertFalse(
+			$options['signed'],
+			"{$signature}: [signed] must be false for boolean fields."
+		);
+	}
+}

--- a/tests/TestCase/Model/Table/TableTest.php
+++ b/tests/TestCase/Model/Table/TableTest.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * Test Classes for the Table Class.
+ */
+
 namespace App\Test\TestCase\Model\Table;
 
 use App\Model\Table\Table;


### PR DESCRIPTION
Adds code-sniff style Migrations tests (ensures a minimum level of quality).

Tweaks a few minor things like enabling coverage enforcement on Travis builds by default (new projects should _start_ assuming they will be fully covered.)