### PR TITLE
Editorconfig Should Not Dictate the Standard Tab Size

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,6 @@ root = true
 ; Unix style newlines and a final newline for all files.
 [*]
 indent_style = tab
-indent_size = 4
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true


### PR DESCRIPTION
Kinda defeats the intent of using tabs if the size is dictated.