### PR TITLE
Exclude .ctp files from coverage, add ConfigReadShell plugin.

### DIFF
--- a/Config/phpunit.xml
+++ b/Config/phpunit.xml
@@ -9,6 +9,7 @@
 			<directory>../Vendor</directory>
 			<directory>../Plugin/DebugKit</directory>
 			<directory>../Plugin/Migrations</directory>
+			<directory suffix=".ctp">../View</directory>
 			<!-- Project-specific exclusions. -->
 		</blacklist>
 	</filter>
@@ -23,7 +24,7 @@
 			highLowerBound="90"
 		/>
 		<!-- Not currently used, but include the config anyway so it's here already. -->
-		<!-- 
+		<!--
 		<log
 			type="coverage-clover"
 			target="../tmp/coverage/clover.xml"

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
     "license": "proprietary",
     "require": {
         "cakephp/cakephp": "2.6.*",
-        "loadsys/cakephp-shell-scripts": "~2.1"
+        "loadsys/cakephp-shell-scripts": "~2.1",
+        "loadsys/cakephp-config-read": "~2.0"
     },
     "config": {
         "vendor-dir": "Vendor/",


### PR DESCRIPTION
Cleans up a few details for the Cake 2 version of the skeleton.
